### PR TITLE
google service is now more clear about file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import fest
 
 # Connect to Graph API & Calendar API
 graphapi = facebook.GraphAPI('<facebook-page-token>')
-calendarapi = discovery.build('calendar', 'v3', cache_discovery=False)
+calendarapi = discovery.build('<path to client_secret.json>', 'v3', cache_discovery=False)
 
 # Get Page/Calendar objects
 page = fest.FacebookPage(graphapi, '<facebook-page-name-or-id>')

--- a/docs/google.md
+++ b/docs/google.md
@@ -27,7 +27,7 @@ Create an instance of the Google Calendar API client:
 ```python
 from googleapiclient import discovery
 
-calendarapi = discovery.build('calendar', 'v3', cache_discovery=False)
+calendarapi = discovery.build('<path to client_secret.json>', 'v3', cache_discovery=False)
 ```
 
 Use this client as an input to `fest.GoogleCalendar`:


### PR DESCRIPTION
After quite some time cracking at the base example I finally figured that the build needs the filepath. I altered this in the readmes